### PR TITLE
Uppdatera ConfigureAwait-sektion med Microsoft-länkar

### DIFF
--- a/c# coding guidelines.md
+++ b/c# coding guidelines.md
@@ -173,8 +173,13 @@ var result = await GetDataAsync(); // Bra
 ```csharp
 await _httpClient.SendAsync(request).ConfigureAwait(false);
 ```
+Bibliotek bör inte anta någon specifik synkroniseringskontext.
+`ConfigureAwait(false)` låter fortsättningen ske på valfri tråd och minskar risken för deadlocks.
+Mer läsning:
+- [ConfigureAwait FAQ](https://devblogs.microsoft.com/dotnet/configureawait-faq/)
+- [Asynchronous programming with async and await](https://learn.microsoft.com/dotnet/csharp/programming-guide/concepts/async/)
 
-### 4.6 Parallellisering  
+### 4.6 Parallellisering
 ```csharp
 await Task.WhenAll(method1Async(), method2Async());
 ```


### PR DESCRIPTION
## Summary
- förtydliga varför `ConfigureAwait(false)` används i bibliotek
- lägg till länkar till Microsofts officiella resurser för vidare läsning

## Testing
- `n/a`


------
https://chatgpt.com/codex/tasks/task_e_68413e3d84fc832f8c52f7bd1514c143