### PR TITLE
Add property spacing rule with examples

### DIFF
--- a/c# coding guidelines.md
+++ b/c# coding guidelines.md
@@ -125,9 +125,20 @@ Används endast när:
 ---
 
 ### 2.10 Tomma rader mellan properties
- - Sätt en tom rad mellan varje property för tydlighetens skull.
+- Sätt en tom rad mellan varje property för tydlighetens skull.
+- Undantag: Om hela klassen enbart består av autoimplementerade getters och setters kan properties placeras direkt efter varandra utan tom rad emellan.
 
-Undantag: Om hela klassen enbart består av autoimplementerade getters och setters kan properties placeras direkt efter varandra utan tom rad emellan.
+**Ej så här:**
+```csharp
+public DateTime Birthdate { get; set; }
+public Gender Gender { get; set; }
+```
+
+**Okej i klasser som enbart består av autoimplementerade properties:**
+```csharp
+public int Id { get; set; }
+public string Name { get; set; }
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- document rule about blank lines between properties
- show example of disallowed adjacent properties and allowed grouping for DTOs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fc77dfae0832f82d4692a600813be