### PR TITLE
Add rule requiring braces for control flow

### DIFF
--- a/c# coding guidelines.md
+++ b/c# coding guidelines.md
@@ -130,6 +130,23 @@ Används endast när:
 Undantag: Om hela klassen enbart består av autoimplementerade getters och setters kan properties placeras direkt efter varandra utan tom rad emellan.
 
 ---
+### 2.11 Klamrar runt kontrollflöde
+
+- Använd alltid klamrar `{}` för `if`, `else`, `for`, `while` m.m., även när blocket bara innehåller en rad.
+
+```csharp
+// Fel
+if (isReady)
+    Run();
+
+// Rätt
+if (isReady)
+{
+    Run();
+}
+```
+
+---
 
 ## Kapitel 3: Felhantering & Undantag
 


### PR DESCRIPTION
## Summary
- add new guideline for always using `{}` on control-flow statements

## Testing
- `git diff --color --unified=3`


------
https://chatgpt.com/codex/tasks/task_e_684ffbe97d24832faa0ec924e79e4b75